### PR TITLE
Make Chrome extension operational again

### DIFF
--- a/chrome/README.md
+++ b/chrome/README.md
@@ -22,14 +22,24 @@ repositories to Sourcegraph.
 
 ## Development
 
-To build, run `gulp`. Then go to `chrome:extensions` in Chrome and use *Load Unpacked Extension* to
-load the `chrome/build` extension directory.
+## Prerequisites
+
+Install [Gulp](https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md#getting-started) and [NodeJS](https://nodejs.org/en/download/), then install the dependencies:
+```
+cd chrome/
+npm install
+```
+
+## Building
+
+To build and watch the source files for changes, run `gulp`. Then go to `chrome://extensions`
+in Chrome, check "Developer mode" and use *Load Unpacked Extension* to load the
+`chrome/build` extension directory.
 
 To reload the Chrome extension when you change files, install
 [Extensions Reloader](https://chrome.google.com/webstore/detail/fimgfedafeadlieiabdeeaodndnlbhid)
-and run `grunt watch`.
+and run `gulp watch`.
 
-To inject content from https://localhost:3000 instead of from
-https://sourcegraph.com, set the env var `DEV=1` on the `grunt` command.
-
-
+To inject content from http://localhost:3080 instead of from
+https://sourcegraph.com, run `DEV=1 grunt`. GitHub is HTTPS-only, so you may
+need to [allow mixed content](http://superuser.com/a/487772) temporarily.

--- a/chrome/github.js
+++ b/chrome/github.js
@@ -133,17 +133,17 @@ function GitHubPage(doc) {
   };
 
   function getAnnotatedCode(info, codeElem, callback) {
-    var url = '<%= url %>/api/repos/' + info.repoid + '@' + info.branch + '/.tree/' + info.path + '?Formatted=true&ContentsAsString=true';
+    var url = '<%= url %>/.api/repos/' + info.repoid + '@' + info.branch + '/.tree/' + info.path + '?Formatted=true&ContentsAsString=true';
     get(url, callback);
   }
 
   function getRepositoryBuild(repo_id, commitID, callback) {
-    var url = '<%= url %>/api/repos/' + repo_id + '@' + commitID + '/.build'
+    var url = '<%= url %>/.api/repos/' + repo_id + '@' + commitID + '/.build'
     get(url, callback);
   }
 
   function addRepository(repo_id) {
-    var url = '<%= url %>/api/repos/'+repo_id;
+    var url = '<%= url %>/.api/repos/'+repo_id;
     var req = new XMLHttpRequest();
     req.open('PUT', url, true);
     req.send();

--- a/chrome/github.js
+++ b/chrome/github.js
@@ -100,7 +100,7 @@ function GitHubPage(doc) {
         // Create <tr> per line.
         var html = fileInfo.ContentsString.split("\n").map(function(line, i) {
           var lineno = i + 1;
-          return '<tr class="line"><td id="L' + lineno + '" class="blob-num js-line-number" data-line-number=' + lineno + '></td><td id="LC' + lineno + '" class="blob-code js-file-line">' + line + '</td></tr>';
+          return '<tr class="line"><td id="L' + lineno + '" class="blob-num js-line-number" data-line-number=' + lineno + '></td><td id="LC' + lineno + '" class="blob-code blob-code-inner js-file-line">' + line + '</td></tr>';
         }).join("");
 
         // Prepare linked code

--- a/chrome/github.js
+++ b/chrome/github.js
@@ -138,7 +138,11 @@ function GitHubPage(doc) {
   }
 
   function getRepositoryBuild(repo_id, commitID, callback) {
-    var url = '<%= url %>/.api/repos/' + repo_id + '@' + commitID + '/.build'
+    var url = '<%= url %>/.api/repos/' + repo_id;
+    if(commitID) {
+      url += '@'+commitID;
+    }
+    url += '/.build';
     get(url, callback);
   }
 

--- a/chrome/github.scss
+++ b/chrome/github.scss
@@ -16,121 +16,112 @@ $gh-header-border: 1px solid #d2d9dd;
         }
     }
 
-    .kwd, .typ { font-weight: bold; }
-
     /* GitHub Theme from http://jmblog.github.io/color-themes-for-google-code-prettify/css/themes/github.css */
 
     .pln {
-        color: #333333;
+      color: #333333;
     }
 
     @media screen {
-        .str {
-            color: #dd1144;
-        }
+      .str {
+        color: #dd1144;
+      }
 
-        .kwd {
-            color: #333333;
-        }
+      .kwd {
+        color: #333333;
+      }
 
-        .com {
-            color: #999988;
-            font-style: italic;
-        }
+      .com {
+        color: #999988;
+      }
 
-        .typ {
-            color: #445588;
-        }
+      .typ {
+        color: #445588;
+      }
 
-        .ref {
-            color: #445588;
-        }
+      .lit {
+        color: #445588;
+      }
 
-        .lit {
-            color: #445588;
-        }
+      .pun {
+        color: #333333;
+      }
 
-        .pun {
-            color: #333333;
-        }
+      .opn {
+        color: #333333;
+      }
 
-        .opn {
-            color: #333333;
-        }
+      .clo {
+        color: #333333;
+      }
 
-        .clo {
-            color: #333333;
-        }
+      .tag {
+        color: navy;
+      }
 
-        .tag {
-            color: navy;
-        }
+      .atn {
+        color: teal;
+      }
 
-        .atn {
-            color: teal;
-        }
+      .atv {
+        color: #dd1144;
+      }
 
-        .atv {
-            color: #dd1144;
-        }
+      .dec {
+        color: #333333;
+      }
 
-        .dec {
-            color: #333333;
-        }
+      .var {
+        color: teal;
+      }
 
-        .var {
-            color: teal;
-        }
-
-        .fun {
-            color: #990000;
-        }
+      .fun {
+        color: #990000;
+      }
     }
     @media print, projection {
-        .str {
-            color: #006600;
-        }
+      .str {
+        color: #006600;
+      }
 
-        .kwd {
-            color: #006;
-            font-weight: bold;
-        }
+      .kwd {
+        color: #006;
+      }
 
-        .com {
-            color: #600;
-            font-style: italic;
-        }
+      .com {
+        color: #600;
+        font-style: italic;
+      }
 
-        .typ {
-            color: #404;
-            font-weight: bold;
-        }
+      .typ {
+        color: #404;
+      }
 
-        .lit {
-            color: #004444;
-        }
+      .lit {
+        color: #004444;
+      }
 
-        .pun, .opn, .clo {
-            color: #444400;
-        }
+      .pun, .opn, .clo {
+        color: #444400;
+      }
 
-        .tag {
-            color: #006;
-            font-weight: bold;
-        }
+      .tag {
+        color: #006;
+        font-weight: bold;
+      }
 
-        .atn {
-            color: #440044;
-        }
+      .atn {
+        color: #440044;
+      }
 
-        .atv {
-            color: #006600;
-        }
+      .atv {
+        color: #006600;
+      }
     }
     /* Specify class=linenums on a pre to get line numbering */
     ol.linenums {
-        margin-top: 0;
-        margin-bottom: 0;
+      margin-top: 0;
+      margin-bottom: 0;
     }
 
     /* IE indents via margin-left */
@@ -144,7 +135,7 @@ $gh-header-border: 1px solid #d2d9dd;
     li.L7,
     li.L8,
     li.L9 {
-    /* */
+      /* */
     }
 
     /* Alternate shading for lines */
@@ -153,7 +144,7 @@ $gh-header-border: 1px solid #d2d9dd;
     li.L5,
     li.L7,
     li.L9 {
-    /* */
+      /* */
     }
 }
 

--- a/chrome/gulpfile.js
+++ b/chrome/gulpfile.js
@@ -12,10 +12,10 @@ uglify = require('gulp-uglify'),
 zip = require('gulp-zip');
 
 var context = {
-  DEV: process.env.DEV,
+  DEV: process.env.DEV || false,
 
   /*global process*/
-  url: (process.env.DEV ? 'http://localhost:3000' : 'https://sourcegraph.com'),
+  url: (process.env.DEV ? 'http://localhost:3080' : 'https://sourcegraph.com'),
 };
 
 // Clean build directory
@@ -68,19 +68,9 @@ gulp.task('styles', function() {
 
 gulp.task('build', ['clean', 'html', 'scripts', 'styles', 'copy']);
 
-gulp.task('reload_chrome_extensions', function() {
-  // /*global require*/
-  // var exec = require('child_process').exec;
-  // exec('chromium-browser http://reload.extensions', function(err) {
-  //   if (err) {
-  //     console.log(err);
-  //   }
-  // });
-});
-
 gulp.task('watch', function() {
-  gulp.watch(['*.js', '*.scss', '*.html', '*.json'], ['build', 'reload_chrome_extensions']);
+  gulp.watch(['*.js', '*.scss', '*.html', '*.json'], ['build']);
 });
 
 // Run all tasks after build directory has been cleaned
-gulp.task('default', ['clean', 'build', 'reload_chrome_extensions', 'watch']);
+gulp.task('default', ['clean', 'build', 'watch']);

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Sourcegraph<%= DEV ? "DEV" : "" %>",
-  "version": "1.0.12",
+  "version": "1.0.2",
   "description": "Browse code on GitHub like you're in an IDE: instant documentation tooltips and jump-to-definition links for code on GitHub",
   "icons": {"128": "icon_128.png"},
   "content_scripts": [

--- a/chrome/package.json
+++ b/chrome/package.json
@@ -3,16 +3,18 @@
   "version": "0.1.1",
   "dependencies": {},
   "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "gulp": "~3.9.0",
     "gulp-clean": "~0.3.0",
-    "gulp-cleanhtml": "0.0.2",
-    "gulp-minify-css": "~0.3.5",
-    "gulp-uglify": "~0.3.1",
-    "gulp-zip": "~0.4.0",
-    "gulp-strip-debug": "~0.3.0",
-    "gulp": "~3.8.1",
-    "gulp-jshint": "~1.6.3",
-    "gulp-preprocess": "~1.1.1",
-    "gulp-template": "~0.1.1",
-    "gulp-sass": "~0.7.2"
+    "gulp-cleanhtml": "1.0.0",
+    "gulp-jshint": "~2.0.0",
+    "gulp-minify-css": "~1.2.2",
+    "gulp-preprocess": "~2.0.0",
+    "gulp-sass": "~2.1.0",
+    "gulp-strip-debug": "~1.1.0",
+    "gulp-template": "~3.1.0",
+    "gulp-uglify": "~1.5.1",
+    "gulp-zip": "~3.0.2"
   }
 }


### PR DESCRIPTION
1. This change makes the chrome extension operate once again exactly as shown in the demonstration video on YouTube.
1. Note it also relies on an accompanying change [here](https://src.sourcegraph.com/sourcegraph/.changes/386) which must be deployed to sourcegraph.com before it will work.
1. Hovering over Go stdlib tokens like `make` etc currently does not work, because the build is failing for that repo currently: https://sourcegraph.com/github.com/golang/go/.builds (all other built repos work just as expected).
1. Attached is a built zip of the extension which can be loaded in unpacked mode (see README.md).
