### PR TITLE
Remove "Search code" button & more closely match syntax highlighting

### DIFF
--- a/chrome/github.js
+++ b/chrome/github.js
@@ -59,15 +59,6 @@ function GitHubPage(doc) {
           console.log('Not adding Sourcegraph links to source code because status:', status);
           return;
         }
-
-        var sgButtonURL = urlToRepoSearch(info.repoid, '');
-        var sgButton = buttonHeader.querySelector('#sg-search-button-container');
-        if (!sgButton) {
-          sgButton = doc.createElement('li');
-          sgButton.id = 'sg-search-button-container';
-          buttonHeader.insertBefore(sgButton, buttonHeader.firstChild);
-        }
-          sgButton.innerHTML = '<a id="sg-search-button" class="minibutton sg-button tooltipped tooltipped-s" aria-label="Search within this repository on Sourcegraph" target="_blank" href="'+sgButtonURL+'">&#x2731; Search code</a>';
       });
     }
 

--- a/chrome/github.scss
+++ b/chrome/github.scss
@@ -24,7 +24,7 @@ $gh-header-border: 1px solid #d2d9dd;
 
     @media screen {
       .str {
-        color: #dd1144;
+        color: #183691;
       }
 
       .kwd {
@@ -64,7 +64,7 @@ $gh-header-border: 1px solid #d2d9dd;
       }
 
       .atv {
-        color: #dd1144;
+        color: #183691;
       }
 
       .dec {

--- a/chrome/github.scss
+++ b/chrome/github.scss
@@ -28,7 +28,7 @@ $gh-header-border: 1px solid #d2d9dd;
       }
 
       .kwd {
-        color: #333333;
+        color: #a71d5d;
       }
 
       .com {

--- a/chrome/github.scss
+++ b/chrome/github.scss
@@ -19,7 +19,7 @@ $gh-header-border: 1px solid #d2d9dd;
     /* GitHub Theme from http://jmblog.github.io/color-themes-for-google-code-prettify/css/themes/github.css */
 
     .pln {
-      color: #333333;
+      color: #a71d5d;
     }
 
     @media screen {
@@ -28,7 +28,7 @@ $gh-header-border: 1px solid #d2d9dd;
       }
 
       .kwd {
-        color: #a71d5d;
+        color: #0086b3;
       }
 
       .com {
@@ -36,11 +36,11 @@ $gh-header-border: 1px solid #d2d9dd;
       }
 
       .typ {
-        color: #445588;
+        color: #ed6a43;
       }
 
       .lit {
-        color: #445588;
+        color: #ed6a43;
       }
 
       .pun {

--- a/chrome/github.scss
+++ b/chrome/github.scss
@@ -32,7 +32,7 @@ $gh-header-border: 1px solid #d2d9dd;
       }
 
       .com {
-        color: #999988;
+        color: #969896;
       }
 
       .typ {


### PR DESCRIPTION
This change helps to move further towards the same exact GitHub syntax highlighting, but it's not perfect as our syntax highlighter is different than GitHub's and ours tends to group many Go keywords etc together so we can't style them independently at all.

Here is a screenshot of ours after this change (left) and GitHubs without the extension (right):

![image](https://cloud.githubusercontent.com/assets/3173176/12129940/06fdcc8e-b3c4-11e5-8e2e-69771cfa1261.png)

White text in the screenshot on the left is simply considered identical/`pln` by our highlighter and thus we can't independently color e.g. the function name in `setVars(req, match.Vars)` or method name in `url.String()`.

Unless we opt to spend more time on an extravagant/complex solution here, I don't think we'll be able to get much closer to GitHub's syntax highlighting.
